### PR TITLE
downgrade progress report to debug

### DIFF
--- a/src/supervisor3.erl
+++ b/src/supervisor3.erl
@@ -1599,4 +1599,4 @@ extract_child(Child) ->
 report_progress(Child, SupName) ->
     Progress = [{supervisor, SupName},
                 {started, extract_child(Child)}],
-    error_logger:info_report(progress, Progress).
+    logger:log(debug, Progress).


### PR DESCRIPTION
A PR to resolve this [Issue](https://github.com/kafka4beam/brod/issues/542#issue-1466248201) in the [brod repo](https://github.com/kafka4beam/brod).

This is also an issue for us because we need to pass `password` in our ssl options in `brod` when starting our client supervisor. As a result we are logging our password in plain text. As per the discussion in the linked issue it seems that downgrading this log to `debug` is acceptable. This solution would also solve our issue since we ignore `debug` logs in production.